### PR TITLE
Making specific GlideRecord calls

### DIFF
--- a/Making specific GlideRecord calls
+++ b/Making specific GlideRecord calls
@@ -1,0 +1,114 @@
+/**  
+     * @method getRecords
+     * @desc get all rows from given table based on params  
+     * @param {string} table - name of the table to be queried
+     * @param {string} query - encoded query to be used for GlideRecord & GlideRecordSecure API includes also order by condition
+     * @param {string[]} fieldArr - list of field names from table which need to be contained in output each field will be added to the output with value and display value
+     * @param {DT_OM_CONSTANTS.GR.OFFSET_0 | number} offset - position in result set from where to start adding records to the result; requires OrderBy-Condition in query	  
+     * @param {DT_OM_CONSTANTS.GR.LIMIT_DEFAULT | number} limit - maximum number records contained in result
+     * @param {boolean DT_OM_CONSTANTS.GR.SECURE_ON | DT_OM_CONSTANTS.GR.SECURE_OFF} secured - true -> use GlideRecordSecure API / false -> use GlideRecord API
+     * @returns Array of objects containing the values and display values for each field defined in fieldArr alongwith static fields
+     */
+	getRecords: function(table, query, fieldArr, offset, limit, secured) {
+		//set initial values if not given
+		//if no offset is given "0" is taken as default
+
+		try {
+			if (gs.nil(offset)) {
+				offset = DT_OM_CONSTANTS.GR.OFFSET_0;
+			}
+			if (gs.nil(limit)) {
+				limit = DT_OM_CONSTANTS.GR.LIMIT_DEFAULT;
+			}
+			if (gs.nil(query)) {
+				query = "";
+			}
+
+			//set method variables
+			var grTableRecords;
+			var recordsArr = [];
+
+			//check if fieldArr is an object. If yes convert the keys into an array
+			if (typeof fieldArr === 'object' && fieldArr !== null && !Array.isArray(fieldArr)) {
+				fieldArr = Object.keys(fieldArr);
+			}
+
+			//depending on the "secured" value a different Gliderecord Method is choosed
+			if (secured) {
+				grTableRecords = new GlideRecordSecure(table);
+			} else {
+				grTableRecords = new GlideRecord(table);
+			}
+			grTableRecords.addEncodedQuery(query);
+			grTableRecords.setLimit(limit);
+			grTableRecords.chooseWindow(offset, offset + limit);
+			grTableRecords.query();
+		
+			//iterate over given glideRecords
+			while (grTableRecords.next()) {
+				try {
+					var obj = {};
+					//check if there are fields
+					//iterate over fields array to retrieve all the fields that are given for the output
+					for (var field in fieldArr) {
+						//check for use of dotwalking
+						if (!fieldArr[field].includes('.')) {
+							/* Deprecated: Name added and combined displayValue and Value into one object as given in Object Structure for Widgets
+                            	obj[fieldArr[field]] = grTableRecords.getValue(fieldArr[field]);
+                            	obj[fieldArr[field] + "_display_value"] = grTableRecords.getDisplayValue(fieldArr[field]);
+                            */
+							obj[fieldArr[field]] = ({
+								value: grTableRecords.getValue(fieldArr[field]),
+								displayValue: grTableRecords.getDisplayValue(fieldArr[field]),
+								name: fieldArr[field]
+							});
+						} else {
+							/* Deprecated: Name added and combined displayValue and Value into one object as given in Object Structure for Widgets
+							obj[fieldArr[field].replace(/\./g, "_")] = grTableRecords.getElement(fieldArr[field]).toString();
+							obj[fieldArr[field].replace(/\./g, "_") + "_display_value"] = grTableRecords.getDisplayValue(fieldArr[field]);
+                        */
+							obj[fieldArr[field].replace(/\./g, "_")] = ({
+								value: grTableRecords.getElement(fieldArr[field]).toString(),
+								displayValue: grTableRecords.getDisplayValue(fieldArr[field]),
+								name: fieldArr[field]
+							});
+						}
+					}
+					//add sys_id to object
+					obj.sys_id = grTableRecords.getValue('sys_id');
+					recordsArr.push(obj);
+				} catch (e) {
+					throw {
+						"script_include": this.type,
+						"method": "getRecords",
+						"param": [table, query, fieldArr, offset, limit, secured],
+						"source": e,
+						"error": e.message
+					};
+				}
+			}
+			return recordsArr;
+		} catch (ex) {
+			throw {
+				"script_include": this.type,
+				"method": "getRecords",
+				"param": [table, query, fieldArr, offset, limit, secured],
+				"source": ex,
+				"error": ex.message
+			};
+
+
+//calling this function from another script include
+
+ga = <object>.getRecords(
+                        "x_dtbsg_ordertrack_order_milestones",
+                        "customer_order_line_item=" + <value of site> + "^state=" + <state value> + "^ORDERBYsequence",
+                        ["milestone", "state"],
+                        0,
+                        null,
+                        true
+                    );
+//check if ga has records
+                if (ga.length != 0) {
+                   //perform operation
+}

--- a/fetch data from multiple table but call GlideRecord ONCE
+++ b/fetch data from multiple table but call GlideRecord ONCE
@@ -1,0 +1,122 @@
+try {
+            var tablename, query, query2, rel_param_pref1, rel_param_pref2, rel_param;
+            rel_param_pref2 = '';
+            tablename = '';
+            switch (milestone) {
+                case 'Create SAP Record (Businesss Sales Order) for Software':
+                    tablename = 'proc_po';
+                    query = 'u_order_line=' + coli;
+                    rel_param_pref1 = "ZTL2: ";
+                    rel_param = 'u_sap_sales_order_number';
+                    break;
+
+                case 'Create SAP Purchase Order for Software':
+                    tablename = 'proc_po';
+                    query = 'u_order_line=' + coli;
+                    rel_param_pref1 = "PO#: ";
+                    rel_param = 'u_sap_po_number';
+                    break;
+                    // u_sap_po_number is inactive 
+
+                case 'Adding Serial Number':
+                    var gr_coli = new GlideRecord('sn_ind_tmt_orm_order_line_item');
+                    gr_coli.addEncodedQuery('product_specification=9a2eab1df7d2c1105ef541b84851e0ed^top_line_item.sys_id=' + coli);
+                    gr_coli.query();
+                    while (gr_coli.next()) {
+                        var cpe_coli = new GlideRecord('sn_ind_tmt_orm_order_characteristic_value');
+                        cpe_coli.addEncodedQuery('specification.external_id=62002891^characteristic.name=CPE_role^order_line_item=' + gr_coli.sys_id);
+                        cpe_coli.query();
+                        if (cpe_coli.next()) {
+                            if (cpe_coli.getDisplayValue('characteristic_option_value') == 'primary') {
+                                rel_param_pref1 = 'Serial number CPE1#: ';
+                                query = 'characteristic.name=serial_number^specification.external_id=62002891^characteristic_option_value!=NULL^order_line_item=' + gr_coli.sys_id;
+                            } else if (cpe_coli.getDisplayValue('characteristic_option_value') == 'secondary') {
+                                rel_param_pref2 = 'Serial number CPE2#: ';
+                                query2 = 'characteristic.name=serial_number^specification.external_id=62002891^characteristic_option_value!=NULL^order_line_item=' + gr_coli.sys_id;
+                            }
+                        }
+                    }
+                    tablename = 'sn_ind_tmt_orm_order_characteristic_value';
+                    rel_param = 'characteristic_option_value';
+                    break;
+
+                case 'Activate License':
+                    var gr_coli = new GlideRecord('sn_ind_tmt_orm_order_line_item');
+                    gr_coli.addEncodedQuery('product_specification=9a2eab1df7d2c1105ef541b84851e0ed^top_line_item.sys_id=' + coli);
+                    gr_coli.query();
+                    while (gr_coli.next()) {
+                        var cpe_coli = new GlideRecord('sn_ind_tmt_orm_order_characteristic_value');
+                        cpe_coli.addEncodedQuery('specification.external_id=62002891^characteristic.name=CPE_role^order_line_item=' + gr_coli.sys_id);
+                        cpe_coli.query();
+                        if (cpe_coli.next()) {
+                            if (cpe_coli.getDisplayValue('characteristic_option_value') == 'primary') {
+                                rel_param_pref1 = 'License CPE1#: ';
+                                query = 'attribute=SecurityLicenceKey^order_line_item=' + gr_coli.sys_id;
+                            } else if (cpe_coli.getDisplayValue('characteristic_option_value') == 'secondary') {
+                                rel_param_pref2 = 'License CPE2#: ';
+                                query2 = 'attribute=SecurityLicenceKey^order_line_item=' + gr_coli.sys_id;
+                            }
+                        }
+                    }
+                    tablename = 'x_dtbsg_dt_order_m_order_line_item_attribute';
+                    rel_param = 'value';
+                    break;
+
+                case 'Confirm Shipping':
+                    tablename = 'proc_po_item';
+                    query = 'purchase_order.u_order_line.specification.external_id=62002891^purchase_order.u_order_line=' + coli;
+                    rel_param_pref1 = 'Shipping ID: ';
+                    rel_param = 'u_shipping_id';
+                    break;
+
+                case 'Confirm Installation Date':
+                    tablename = 'x_dtbsg_dt_order_m_order_line_item_attribute';
+                    query = 'attribute=ConfirmedInstallationDate^order_line_item=' + coli;
+                    rel_param_pref1 = 'Installation Date: ';
+                    rel_param = 'value';
+                    break;
+
+                case 'Provide Contact Data for Operations Level 2 Team Technician':
+                    tablename = 'x_dtbsg_dt_order_m_order_line_item_attribute';
+                    query = 'attribute=OPSL2TechnicianName^order_line_item=' + coli;
+                    rel_param_pref1 = 'Contact: ';
+                    rel_param = 'value';
+                    break;
+            }
+            var result1 = '',
+                result2 = '',
+                result = [];
+            if (rel_param_pref1 && tablename) {
+                var gr = new GlideRecord(tablename + '');
+                gr.addEncodedQuery(query);
+                gr.query();
+                while (gr.next()) {
+                    if (gr.getDisplayValue(rel_param) != '') {
+                        result1 = rel_param_pref1 + gr.getDisplayValue(rel_param);
+                        result.push(result1);
+                    }
+                }
+            }
+            if (rel_param_pref2) {
+                var gr1 = new GlideRecord(tablename + '');
+                gr1.addEncodedQuery(query2);
+                gr1.query();
+                while (gr1.next()) {
+                    if (gr.getDisplayValue(rel_param) != '') {
+                        result2 = rel_param_pref2 + gr1.getDisplayValue(rel_param);
+                        result.push(result2);
+                    }
+                }
+            }
+            return result;
+
+        } catch (err) {
+            throw errorObj = {
+                "script_include": this.type,
+                "method": "_getRelatedParameter",
+                "source": {},
+                "param": [milestone, coli],
+                "error": JSON.stringify(err)
+            };
+
+        }


### PR DESCRIPTION
When calling GlideRecord, we get all the columns of the record in return. Whereas we only need some. We actually dont make use of 80-90% of columns, we operate on 10% only. 
Using this approach we are only fetching the fields we need, and if it needs to be returned in secure way. 
I have applied constraints such as:

- table name
- put the encoded query
- field array with required fields
- offset -position in result set from where to start adding records to the result
- limit the maximum number of record to be fetched