### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ There are multiple projects we are encouraging participation in. To finish your 
 
 ## Have a ServiceNow app you want to open to collaboration?
 
-Reach out to Earl Duque and we'll get your repo officially hosted.
+Reach out to [Earl Duque](https://sndevs.slack.com/team/U7WGPRC2D) ([earl.duque@servicenow.com](mailto:earl.duque@servicenow.com)) and we'll get your repo officially hosted.
 
 # <br><a name="points" href="#points">![points](/images/4points.png)</a>
 


### PR DESCRIPTION
Under the "get your own project added section" I have:
- turned Earl Duque's name to a URL that links t his Slack profile
- added his @servicenow.com email address with a mailto link.

Feel free to reject or edit as you see fit. I just thought it would make sense if people actually have a channel (or more) to get in touch, rather than just a name to figure out the rest.