### PR TITLE
issue:#25   Adding Code Of Conduct file.html

### DIFF
--- a/Code of conduct.html
+++ b/Code of conduct.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Code of Conduct</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 20px;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+
+        header {
+            background-color: #24292e;
+            color: white;
+            padding: 10px 0;
+            text-align: center;
+        }
+
+        header h1 {
+            margin: 0;
+        }
+
+        section {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+            margin: 20px auto;
+            max-width: 800px;
+        }
+
+        h2 {
+            color: #333;
+            border-bottom: 2px solid #eaeaea;
+            padding-bottom: 10px;
+        }
+
+        p {
+            color: #555;
+        }
+
+        ul {
+            padding-left: 20px;
+        }
+
+        li {
+            margin-bottom: 10px;
+        }
+
+        footer {
+            text-align: center;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Code of Conduct</h1>
+    </header>
+
+    <section>
+        <h2>Our Pledge</h2>
+        <p>In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
+
+        <h2>Our Standards</h2>
+        <p>Examples of behavior that contributes to creating a positive environment include:</p>
+        <ul>
+            <li>Using welcoming and inclusive language</li>
+            <li>Being respectful of differing viewpoints and experiences</li>
+            <li>Gracefully accepting constructive criticism</li>
+            <li>Focusing on what is best for the community</li>
+            <li>Showing empathy towards other community members</li>
+        </ul>
+
+        <p>Examples of unacceptable behavior by participants include:</p>
+        <ul>
+            <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
+            <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+            <li>Public or private harassment</li>
+            <li>Publishing others' private information, such as a physical or electronic address, without explicit permission</li>
+            <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+        </ul>
+
+        <h2>Our Responsibilities</h2>
+        <p>Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.</p>
+
+        <h2>Scope</h2>
+        <p>This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.</p>
+
+        <h2>Enforcement</h2>
+        <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [email address]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.</p>
+
+        <h2>Attribution</h2>
+        <p>This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a></p>
+    </section>
+
+    <footer>
+        <p>&copy; 2024 Your Project Name. All rights reserved.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
This code of conduct template defines community standards for your GitHub project. It begins with a pledge to ensure a harassment-free environment, embracing inclusivity regardless of personal attributes such as gender, race, or experience. The standards section outlines positive behaviors like using inclusive language and respecting differing opinions, while also listing unacceptable actions like harassment or trolling. Responsibilities of project maintainers include enforcing these standards and addressing any misconduct. The code applies both in project spaces and public contexts where individuals represent the project. An enforcement section explains how to handle reports of violations, maintaining confidentiality. Finally, the code attributes its structure to the Contributor Covenant.